### PR TITLE
COURSESPLT-27 : Fix Course Schedule bubble display

### DIFF
--- a/courses-portlet-webapp/src/main/webapp/less/jquery.timetable.less
+++ b/courses-portlet-webapp/src/main/webapp/less/jquery.timetable.less
@@ -71,6 +71,8 @@
     font-size: .7em;
 
     cursor: pointer;
+
+    box-sizing: content-box;
   }
 
   &.isStandaloneSchedule {


### PR DESCRIPTION
Bootstrap box-sizing css was causing incorrect height calculations in jquery timetable.  So set box-sizing to default explicitly so element does not inherit bootstrap box-sizing value.